### PR TITLE
Re: Install

### DIFF
--- a/efi_c/efi.c
+++ b/efi_c/efi.c
@@ -2489,7 +2489,7 @@ EFI_STATUS efi_main(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable) {
         u"Print EFI Global Variables",
         u"Load Kernel",
         u"Change Boot Variables",
-        u"Write Disk Image Image To Other Disk",
+        u"Write Disk Image To Other Disk",
         u"Install Bootloader & Autoload Kernel",
     };
 


### PR DESCRIPTION
With `Write Disk Image To Other Disk` and `Install Bootloader & Autoload Kernel`, this doesn't solve the issue of being without removable media. Limited to existing media, however formatted; how would a data partition come into existence? The implementation thereof a workaround to allow kernel loading as [we haven't seen that done](https://github.com/queso-fuego/uefi-dev/issues/12) with only the EFI System Partition available for use.